### PR TITLE
Add files via upload

### DIFF
--- a/scripts/mssql-ag-setup/README.md
+++ b/scripts/mssql-ag-setup/README.md
@@ -16,9 +16,10 @@ on start-up are both important and time consuming.
 Beginnning with SQL Server 2019 CU11, there is a bug which causes Availability 
 Groups to fail if the mssql resource agent is configured to use the fully 
 qualified host name (eg. host1.domain) instead of the system name (eg. host). 
-The latest implementation of these scripts uses this workaround.  Make sure 
-your DNS (or host file) is configured to use system names as well as host 
-names in mappings to IP addresses.
+The latest implementation of these scripts works around this by using the 
+system name.  It is also highly recommended that you specify the specific 
+network addresses that you plan to use for pacemaker communications on your
+hosts.
 
 I used to recommend that you temporarily setup passwordless ssh root host 
 equvalence between the cluster nodes using ssh-keygen and ssh-copy-id but 

--- a/scripts/mssql-ag-setup/initvars.sh
+++ b/scripts/mssql-ag-setup/initvars.sh
@@ -32,7 +32,13 @@ ALL_SERVERS_NB=""
 
 for server in $ALL_SERVERS
 do
-    ALL_SERVERS_NB+=`echo $server | awk -F . '{ print $1 }'`" "
+    server=`echo $server | awk -F . '{ print $1 }'`
+    if [ -z ${ALL_SERVERS_ADDR[$server]} ]
+    then
+        ALL_SERVERS_NB="$ALL_SERVERS_NB $server "
+    else
+        ALL_SERVERS_NB="$ALL_SERVERS_NB $server addr=${ALL_SERVERS_ADDR[$server]} "
+    fi
 done
 
 if [ $CLUSTER_TYPE = "EXTERNAL" ]

--- a/scripts/mssql-ag-setup/params.sh
+++ b/scripts/mssql-ag-setup/params.sh
@@ -5,7 +5,7 @@
 # Debug mode.  If set to 1, then unsuccesful sql commands are saved
 # to /tmp.  We do not save them there by default since they can
 # contain passwords.
-DEBUG_MODE=0
+DEBUG_MODE=1
 
 # Update PATH to include sqlcmd as it will be needed
 PATH=$PATH:/opt/mssql-tools/bin
@@ -121,8 +121,19 @@ CLUSTER_TYPE="EXTERNAL"
 #
 # There can be at most 9 servers in a writeable SQL Server Availability Group.
 #
+# In addition to the password, Pacemaker also likes to know which
+# network interfaces to use for it's traffic.  This ideally isn't the 
+# same network interface as you are using for SQL Server replication or
+# for external SQL traffic.  It is possible to just use one network link,
+# but that's not very reliable in an enterprise environment.
+# 
+#
+#
 # The default example sets the hostname but no password. 
-declare -A PRIMARY_SERVER_PASS=(["sql1"]="")
+declare -A PRIMARY_SERVER_PASS=(["sql1.ag1"]="")
+declare -A ALL_SERVERS_ADDR=()
+
+
 
 # You can set the host name and password as follows:
 #
@@ -130,6 +141,15 @@ declare -A PRIMARY_SERVER_PASS=(["sql1"]="")
 #
 # In the above example, the server name is sql1.ag1 and the password is 
 # set to: passwd1
+# 
+# You can set the address as follows:
+#
+#    declare -A PRIMARY_SERVER_ADDR=(["sql1"]="192.168.200.120")
+#
+# You can use a non-default network link by setting the host addresses 
+# in ALL_SERVERS_ADDR using the systemnames (not FQDNs) as keys.
+#
+# ALL_SERVERS_ADDR+=(["sql1"]="192.168.200.120")
 #
 
 # Sync replica servers.  You can have up to 5 syncronous replicas
@@ -139,7 +159,22 @@ declare -A PRIMARY_SERVER_PASS=(["sql1"]="")
 # By default, we'll configure servers sql2.ag1 and sql3.ag1 but leave 
 # the passords unset since we're relying on ssh key's only for security.
 #
-declare -A SYNC_SERVERS_PASS=(["sql2"]="" ["sql3"]="")
+# In addition to the password, Pacemaker also likes to know which
+# network interfaces to use for it's traffic.  This ideally isn't the 
+# same network interface as you are using for SQL Server replication or
+# for external SQL traffic.  It is possible to just use one network link,
+# but that's not very reliable in an enterprise environment.
+#
+declare -A SYNC_SERVERS_PASS=(["sql2.ag1"]="")
+SYNC_SERVERS_PASS+=(["sql3.ag1"]="")
+
+# As above, you can use a non-default network link by setting the host 
+# addresses in ALL_SERVERS_ADDR using the systemnames (not FQDNs) as keys.
+#
+# ALL_SERVERS_ADDR+=(["sql1"]="192.168.200.120")
+#
+# ALL_SERVERS_ADDR+=(["sql2"]="192.168.200.74") 
+# ALL_SERVERS_ADDR+=(["sql3"]="192.168.200.45")
 
 #
 # You can assign passwords as in the following example: 
@@ -148,6 +183,7 @@ declare -A SYNC_SERVERS_PASS=(["sql2"]="" ["sql3"]="")
 #
 # Here the server names sql2.ag1 and sql3.ag1 their respective passwords are
 # set to passwd2 and passwd3
+#
 
 SYNC_SERVERS=${!SYNC_SERVERS_PASS[@]}
 
@@ -158,6 +194,7 @@ SYNC_SERVERS=${!SYNC_SERVERS_PASS[@]}
 #
 # example: 
 # declare -A ASYNC_SERVERS_PASS=(["sql4"]="passwd4" ["sql5"]="passwd5")
+#
 #
 declare -A ASYNC_SERVERS_PASS=()
 ASYNC_SERVERS=${!ASYNC_SERVERS_PASS[@]}
@@ -170,7 +207,7 @@ ASYNC_SERVERS=${!ASYNC_SERVERS_PASS[@]}
 # never actually fail over to it.
 #
 # example: 
-# declare -A CONFIG_ONLY_SERVERS=(["sql6"]="passwd6")
+# declare -A CONFIG_ONLY_SERVERS_PASS=(["sql7"]="passwd6")
 #
 declare -A CONFIG_ONLY_SERVERS_PASS=()
 CONFIG_ONLY_SERVERS=${!CONFIG_ONLY_SERVERS_PASS[@]}

--- a/scripts/mssql-ag-setup/params.sh
+++ b/scripts/mssql-ag-setup/params.sh
@@ -5,7 +5,7 @@
 # Debug mode.  If set to 1, then unsuccesful sql commands are saved
 # to /tmp.  We do not save them there by default since they can
 # contain passwords.
-DEBUG_MODE=1
+DEBUG_MODE=0
 
 # Update PATH to include sqlcmd as it will be needed
 PATH=$PATH:/opt/mssql-tools/bin

--- a/scripts/mssql-ag-setup/pcs-setup.sh
+++ b/scripts/mssql-ag-setup/pcs-setup.sh
@@ -58,7 +58,6 @@ server=$PRIMARY_SERVER
 runsshcmd "$server" "${ALL_SERVERS_PASS[$server]}" pcs host auth -u hacluster -p "$HACLUSTER_PW" $ALL_SERVERS_NB
 runsshcmd "$server" "${ALL_SERVERS_PASS[$server]}" pcs cluster setup $AG_NAME $ALL_SERVERS_NB
 runsshcmd "$server" "${ALL_SERVERS_PASS[$server]}" "pcs cluster start --all; sudo pcs cluster enable --all"
-runsshcmd "$server" "${ALL_SERVERS_PASS[$server]}" pcs cluster auth -u hacluster -p "$HACLUSTER_PW"
 
 sleep 3
 echo "Set the recheck interval of pacemaker to 2 minutes"


### PR DESCRIPTION
This change adds the ability to set the pcs cluster setup option to specify specific host addresses via the ALL_HOSTS_ADDR array in params.sh.  The option is not used by default.  This allows you to pick which interface to use for cluster traffic on each system in the cluster.  It's the best solution for hosts with multiple network interfaces.  I also fixed the all-setup.sh script so that none of the options are commented out by default.